### PR TITLE
OS X throws an `EPIPE` error which was already ignored in the code. Ubun...

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,6 +219,8 @@ Grid.prototype.render = function(fn){
   this.proc.stdin.on('error', function(err){
     if ('EPIPE' == err.code) {
       debug('ignore EPIPE');
+    } else if ('ECONNRESET' == err.code) {
+      debug('ignore ECONNRESET');
     } else {
       onerror(err);
     }


### PR DESCRIPTION
...tu throws `ECONNRESET` instead, so ignore it too.