### PR TITLE
Update/node12

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,2 @@
+lts/erbium
+

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,2 +1,1 @@
 lts/erbium
-

--- a/index.js
+++ b/index.js
@@ -156,7 +156,7 @@ Grid.prototype.args = function(){
   argv.push('-q', this.vquality());
 
   // ensure streaming output
-  argv.push('-updatefirst', 1);
+  argv.push('-update', 1);
 
   // limit threads
   argv.push('-threads', 2);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,65 @@
+{
+  "name": "video-thumb-grid",
+  "version": "0.3.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "assertion-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
+      "integrity": "sha1-x/hUOP3UZrx8oWq5DIFRN5el0js="
+    },
+    "chai": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-1.7.2.tgz",
+      "integrity": "sha1-ugfr1OGsE4opbN9pB3znS39KExc=",
+      "requires": {
+        "assertion-error": "1.0.0"
+      }
+    },
+    "debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "requires": {
+        "ms": "0.7.1"
+      }
+    },
+    "jpeg-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/jpeg-stream/-/jpeg-stream-0.1.0.tgz",
+      "integrity": "sha1-sysk+/PZ/3mjEy1tguqu5hLvxLo="
+    },
+    "ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+    },
+    "picha": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/picha/-/picha-0.5.4.tgz",
+      "integrity": "sha512-iEG8/vZtlYrftwzxFgTLxP+IforkmDCjtM3wHkY1c9WB6uGZ1WVt5rQrCA5JF4CRFTlLZahy+cUu6Dl7z2+c9Q==",
+      "requires": {
+        "nan": "^2.14.1"
+      }
+    },
+    "pixel-stack": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/pixel-stack/-/pixel-stack-0.2.1.tgz",
+      "integrity": "sha1-cmwLenx1BjxY2QRrAcWQPWNZyEY="
+    },
+    "timecodeutils": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/timecodeutils/-/timecodeutils-0.0.1.tgz",
+      "integrity": "sha1-mqjNgkcE999EDft8Rh/5/rnPfhY=",
+      "requires": {
+        "chai": "~1.7.2"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,11 +18,11 @@
       }
     },
     "debug": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "requires": {
-        "ms": "0.7.1"
+        "ms": "2.1.2"
       }
     },
     "jpeg-stream": {
@@ -31,9 +31,9 @@
       "integrity": "sha1-sysk+/PZ/3mjEy1tguqu5hLvxLo="
     },
     "ms": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "nan": {
       "version": "2.14.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "debug": "2.2.0",
     "jpeg-stream": "0.1.0",
-    "picha": "0.4.9",
+    "picha": "^0.5.4",
     "pixel-stack": "0.2.1",
     "timecodeutils": "0.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.3.0",
   "description": "Generates a sprite grid of video thumbnails using `ffmpeg`.",
   "dependencies": {
-    "debug": "2.2.0",
+    "debug": "4.3.1",
     "jpeg-stream": "0.1.0",
-    "picha": "^0.5.4",
+    "picha": "0.5.4",
     "pixel-stack": "0.2.1",
     "timecodeutils": "0.0.1"
   }


### PR DESCRIPTION
Updates to get it running with node12 (due to `video-thumb-server`'s dependency on `videopress-ffmpeg`) and latest `ffmpeg`

**Testing**
1. `npm install`
2. `node example/index.js` should open a thumbnail grid of "big buck bunny".

![grid](https://user-images.githubusercontent.com/4081020/101542660-1452f200-3971-11eb-886e-aad6893b8bf4.jpg)
