### PR TITLE
Add Settings for hard-coded options

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ function Grid(input, fn){
   this._height = 144;
   this._start = 0;
   this._rows = null;
+  this._cmdTimeout = 60;
   this._cmd = 'ffmpeg';
   this._debugprefix = '';
 
@@ -111,6 +112,14 @@ Grid.prototype.interval = function(v){
   return this._interval;
 };
 
+Grid.prototype.cmdTimeout = function(v){
+  if (arguments.length) {
+    this._cmdTimeout= v;
+    return this;
+  }
+  return this._cmdTimeout;
+}
+
 Grid.prototype.cmd = function(v){
   if (arguments.length) {
     this._cmd = v;
@@ -186,11 +195,12 @@ Grid.prototype.render = function(fn){
   this.ffmpegStart = process.hrtime();
   this.proc = spawn(this.cmd(), args);
 
+  var timeout = this.cmdTimeout();
   this._procTimer = setTimeout(function () {
-    console.error('%s: Killing after 60 seconds', self._debugprefix);
+    console.error('%s: Killing after %f seconds', self._debugprefix, timeout);
     self._timeout = true;
     self.abort();
-  }, 60000);
+  }, timeout * 1000);
 
   if (this._stream) {
     this._stream.pipe(this.proc.stdin);

--- a/index.js
+++ b/index.js
@@ -36,6 +36,8 @@ function Grid(input, fn){
   this._start = 0;
   this._rows = null;
   this._cmdTimeout = 60;
+  this._analyzeDuration = '100M';
+  this._probeSize = '100M';
   this._cmd = 'ffmpeg';
   this._debugprefix = '';
 
@@ -114,10 +116,26 @@ Grid.prototype.interval = function(v){
 
 Grid.prototype.cmdTimeout = function(v){
   if (arguments.length) {
-    this._cmdTimeout= v;
+    this._cmdTimeout = v;
     return this;
   }
   return this._cmdTimeout;
+}
+
+Grid.prototype.analyzeDuration = function(v){
+  if (arguments.length) {
+    this._analyzeDuration = v;
+    return this;
+  }
+  return this._analyzeDuration;
+}
+
+Grid.prototype.probeSize = function(v){
+  if (arguments.length) {
+    this._probeSize = v;
+    return this;
+  }
+  return this._probeSize;
 }
 
 Grid.prototype.cmd = function(v){
@@ -142,8 +160,8 @@ Grid.prototype.args = function(){
   // seek
   if (this.start() > 0) argv.push('-ss', time.secondsToTC(this.start()));
 
-  argv.push('-analyzeduration', '100M');
-  argv.push('-probesize', '100M');
+  argv.push('-analyzeduration', this.analyzeDuration());
+  argv.push('-probesize', this.probeSize());
 
   // input stream
   argv.push('-i', this._path || 'pipe:0');


### PR DESCRIPTION
The command timeout is hard coded to 60s which can be low when testing locally in an emulated docker environment.

Additionally, the `analyzeduration` and `probesize` settings are also hard coded.

This PR adds a public config settings so they can be overridden when necessary.

**Testing**
1. add `file.cmdTimeout(1)` to the `example/index.js` file around line 18 to set a very low timeout
2. run `DEBUG=* node index.js` and it should fail with error `ffmpeg took too long.` because 1 second is way too short to perform the necessary thumbnailing
3. set timeout to a higher value (like 100) and run `DEBUG=* node index.js` again, it should complete
4. remove `file.cmdTimeout` and run `DEBUG=* node index.js` and it should use the default 60 second timeout, and complete successfully
5. Additionally, set values for `.analyzeDuration()` and `.probeSize()` and observe that their values change in the logs when the `ffmpeg` command is printed in the debug messages.