### PR TITLE
add user agent property

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ function Grid(input, fn){
   this._probeSize = '100M';
   this._cmd = 'ffmpeg';
   this._debugprefix = '';
+  this._userAgent = '';
 
   this._parser = new JPEGStream;
 
@@ -163,6 +164,14 @@ Grid.prototype.debugprefix = function(v){
   return this._debugprefix;
 };
 
+Grid.prototype.userAgent = function(v){
+  if (arguments.length) {
+    this._userAgent = v;
+    return this;
+  }
+  return this._userAgent;
+};
+
 Grid.prototype.args = function(){
   var argv = [];
 
@@ -171,6 +180,10 @@ Grid.prototype.args = function(){
 
   argv.push('-analyzeduration', this.analyzeDuration());
   argv.push('-probesize', this.probeSize());
+
+  if ( '' !== this.userAgent() ) {
+    argv.push( '-user-agent', this.userAgent() );
+  }
 
   // input stream
   argv.push('-i', this._path || 'pipe:0');


### PR DESCRIPTION
This PR adds a user agent property that will be passed on to the ffmpeg command to be used when the video asset is requested.

**Local Testing** (no docker)
_If on m1, need a patched `picha`_
1. edit `package.json` and replace `picha`'s version with `github:jgcaruso/picha#update/m1-build-support` (hopefully PR gets accepted by picha's dev)

_PR testing_
1. `nvm use` (if testing on m1 `nvm use 16` -- or anything newer than 12)
2. `npm ci`
3. Add the following to `example/index.js`:
   ```
   file.userAgent('test-user-agent');
   console.log(file.args());
   ```
4. If you want to actually test the user-agent is sent by ffmpeg, then start a local webserver (`docker run -d -p 80:80 -v <path-to-video-thumb-grid-repo>/example:/usr/share/nginx/html/ --name jpeg-server nginx`) and change the input variable in `example/index.js` to your server url (ex `http://localhost/sample.mp4`).
5. `node example/index.js` (or `DEBUG=* example/index.js` to see more detail)
6. user agent arg should be printed in the list of args. If running test web server, check logs (`docker logs -f jpeg-server`) to see user agent was sent to the server.